### PR TITLE
ENG-1195 - Add Transaction cost estimate endpoint

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -30,6 +30,7 @@ declare class WebSDK implements iWebSDK {
     logout: () => void;
     createCharge: (charge: ChargeReqBody) => Promise<any>;
     pay: ({ toAddress, chain, symbol, amount, tokenAddress }: Transaction) => Promise<any>;
+    constructRoute: (transactionId: string) => Promise<any>;
     payCharge: (transactionId: string) => Promise<any>;
     getWallets: () => Promise<any>;
     getUserInfo: () => Promise<any>;

--- a/dist/index.js
+++ b/dist/index.js
@@ -344,6 +344,18 @@ class WebSDK {
                 return error;
             }
         });
+        this.constructRoute = (transactionId) => __awaiter(this, void 0, void 0, function* () {
+            try {
+                const requestOptions = yield __classPrivateFieldGet(this, _WebSDK_createRequest, "f").call(this, 'POST', { transactionId });
+                const response = yield fetch(`${this.baseUrl}/constructRoute`, requestOptions);
+                const data = yield response.json();
+                return data.data;
+            }
+            catch (error) {
+                console.error('There was an error constructing this route, error: ', error);
+                return error;
+            }
+        });
         this.payCharge = (transactionId) => __awaiter(this, void 0, void 0, function* () {
             try {
                 const wrappedDek = yield __classPrivateFieldGet(this, _WebSDK_getWrappedDek, "f").call(this);

--- a/dist/index.js
+++ b/dist/index.js
@@ -347,7 +347,7 @@ class WebSDK {
         this.constructRoute = (transactionId) => __awaiter(this, void 0, void 0, function* () {
             try {
                 const requestOptions = yield __classPrivateFieldGet(this, _WebSDK_createRequest, "f").call(this, 'POST', { transactionId });
-                const response = yield fetch(`${this.baseUrl}/constructRoute`, requestOptions);
+                const response = yield fetch(`${this.baseUrl}/pay/route`, requestOptions);
                 const data = yield response.json();
                 return data.data;
             }

--- a/dist/src/types.d.ts
+++ b/dist/src/types.d.ts
@@ -124,3 +124,38 @@ export interface ChargeResponse {
     } | null;
     error: string | null;
 }
+export declare enum TxStatus {
+    PENDING = "PENDING",
+    PROCESSING = "PROCESSING",
+    SUCCESS = "SUCCESS",
+    FAILURE = "FAILURE",
+    CANCELED = "CANCELED",
+    WAITING = "WAITING"
+}
+export interface TransactionEstimate {
+    txId: string;
+    status: TxStatus;
+    total: number;
+    totalUsd: number;
+    estimation: {
+        costUsd: number;
+        timeEstimate: number;
+        gas: string;
+        route: string;
+    };
+    to: {
+        toAmount: string;
+        toAddress: string;
+        toChain: string;
+        toToken: {
+            symbol: string;
+            name: string;
+            decimals: number;
+            address: string;
+            logoURI: string;
+            chain: string;
+        };
+    };
+    startTimestamp: number;
+    limitTimestamp: number;
+}

--- a/dist/src/types.js
+++ b/dist/src/types.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.Environments = exports.WalletTypes = exports.SupportedChains = exports.LoginBehavior = void 0;
+exports.TxStatus = exports.Environments = exports.WalletTypes = exports.SupportedChains = exports.LoginBehavior = void 0;
 var LoginBehavior;
 (function (LoginBehavior) {
     LoginBehavior["REDIRECT"] = "REDIRECT";
@@ -30,3 +30,12 @@ var Environments;
     Environments["STAGING"] = "staging";
     Environments["PRODUCTION"] = "production";
 })(Environments || (exports.Environments = Environments = {}));
+var TxStatus;
+(function (TxStatus) {
+    TxStatus["PENDING"] = "PENDING";
+    TxStatus["PROCESSING"] = "PROCESSING";
+    TxStatus["SUCCESS"] = "SUCCESS";
+    TxStatus["FAILURE"] = "FAILURE";
+    TxStatus["CANCELED"] = "CANCELED";
+    TxStatus["WAITING"] = "WAITING";
+})(TxStatus || (exports.TxStatus = TxStatus = {}));

--- a/index.ts
+++ b/index.ts
@@ -350,7 +350,7 @@ class WebSDK implements iWebSDK {
   constructRoute = async (transactionId: string) => {
     try {
       const requestOptions = await this.#createRequest('POST', { transactionId });
-      const response = await fetch(`${this.baseUrl}/constructRoute`, requestOptions);
+      const response = await fetch(`${this.baseUrl}/pay/route`, requestOptions);
       const data = await response.json();
       return data.data;
     } catch (error: any) {

--- a/index.ts
+++ b/index.ts
@@ -347,6 +347,18 @@ class WebSDK implements iWebSDK {
     }
   };
 
+  constructRoute = async (transactionId: string) => {
+    try {
+      const requestOptions = await this.#createRequest('POST', { transactionId });
+      const response = await fetch(`${this.baseUrl}/constructRoute`, requestOptions);
+      const data = await response.json();
+      return data.data;
+    } catch (error: any) {
+      console.error('There was an error constructing this route, error: ', error);
+      return error;
+    }
+  };
+
   payCharge = async (transactionId: string) => {
     try {
       const wrappedDek = await this.#getWrappedDek();

--- a/index.ts
+++ b/index.ts
@@ -5,6 +5,7 @@ import {
   Environments,
   LoginBehavior,
   Transaction,
+  TransactionEstimate,
   User,
   iWebSDK,
 } from './src/types';
@@ -352,7 +353,7 @@ class WebSDK implements iWebSDK {
       const requestOptions = await this.#createRequest('POST', { transactionId });
       const response = await fetch(`${this.baseUrl}/pay/route`, requestOptions);
       const data = await response.json();
-      return data.data;
+      return data.data as TransactionEstimate;
     } catch (error: any) {
       console.error('There was an error constructing this route, error: ', error);
       return error;

--- a/src/types.ts
+++ b/src/types.ts
@@ -140,3 +140,40 @@ export interface ChargeResponse {
   } | null;
   error: string | null;
 }
+
+export enum TxStatus {
+  PENDING = "PENDING", // Not executed already
+  PROCESSING = "PROCESSING", // Waiting to get mined
+  SUCCESS = "SUCCESS",
+  FAILURE = "FAILURE",
+  CANCELED = "CANCELED",
+  WAITING = "WAITING", // Waiting for user to pay
+}
+
+export interface TransactionEstimate {
+  txId: string, // transactionId
+  status: TxStatus, // TxStatus - WAITING, PROCESSING, COMPLETED, CANCELED, FAILED (should be PENDING)
+  total: number, // total amount initially received, not including other costs
+  totalUsd: number, // USD value of total amount
+  estimation: {
+    costUsd: number, // cost (in usd) to make the transaction
+    timeEstimate: number, // in minutes, rough estimate (for 60 seconds)
+    gas: string, // gas for the transaction
+    route: string, // the route batches that will be executed
+  },
+  to: {
+    toAmount: string, // amount to be received
+    toAddress: string, // receiver address
+    toChain: string, // destination chain
+    toToken: { // extra token metadata
+      symbol: string,
+      name: string,
+      decimals: number,
+      address: string,
+      logoURI: string,
+      chain: string,
+    },
+  },
+  startTimestamp: number, // timestamp when response is sent back to client-side
+  limitTimestamp: number, // timestamp when this route is still valid, minimum
+}


### PR DESCRIPTION
### **PR Description**

Jira Ticket: [ENG-1195](https://sphereone.atlassian.net/browse/ENG-1195)
Jira Ticket: [ENG-1586](https://sphereone.atlassian.net/browse/ENG-1586)

This PR has changes to add the `transaction cost and route estimate` endpoint to the WebSDK. Currently, that endpoint is not being used, but it should be made available, so when it's time to use it, we have it already. Or we can update it when necessary.

### **ChangeLogs**

- added `pay/route` endpoint
- added new data types for `TxStatus` and `TransactionEstimate`

### **Designs**

`No designs.`

### **Additional Notes**

```
Currently, this endpoint is not being used, but it should be called before we ever trigger `pay` or `payCharge`.
Only when user agrees with what's presented to them, do we execute `pay` or `payCharge`.
```

### **Showcase**

```
Nothing to showcase, since it's not being used.
```

[ENG-1195]: https://sphereone.atlassian.net/browse/ENG-1195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ENG-1586]: https://sphereone.atlassian.net/browse/ENG-1586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ