### PR TITLE
ENG-1651 / Add getTransactions method

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -3,7 +3,6 @@ export { Environments as SphereEnvironment } from './src/types';
 export { SupportedChains } from './src/types';
 export { LoginBehavior } from './src/types';
 export { LoginButton } from './src/components/LoginButton';
-
 declare class WebSDK implements iWebSDK {
     #private;
     static instance: WebSDK | undefined;
@@ -32,6 +31,7 @@ declare class WebSDK implements iWebSDK {
     createCharge: (charge: ChargeReqBody) => Promise<any>;
     pay: ({ toAddress, chain, symbol, amount, tokenAddress }: Transaction) => Promise<any>;
     payCharge: (transactionId: string) => Promise<any>;
+    getTransactions: (quantity?: number, getReceived?: boolean, getSent?: boolean) => Promise<any>;
     getWallets: () => Promise<any>;
     getUserInfo: () => Promise<any>;
     getBalances: () => Promise<any>;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -31,7 +31,7 @@ declare class WebSDK implements iWebSDK {
     createCharge: (charge: ChargeReqBody) => Promise<any>;
     pay: ({ toAddress, chain, symbol, amount, tokenAddress }: Transaction) => Promise<any>;
     payCharge: (transactionId: string) => Promise<any>;
-    getTransactions: (quantity?: number, getReceived?: boolean, getSent?: boolean) => Promise<any>;
+    getTransactions: (quantity?: number, getReceived?: boolean, getSent?: boolean) => Promise<Transaction[]>;
     getWallets: () => Promise<any>;
     getUserInfo: () => Promise<any>;
     getBalances: () => Promise<any>;

--- a/dist/index.js
+++ b/dist/index.js
@@ -370,14 +370,20 @@ class WebSDK {
             }
         });
         this.getTransactions = (quantity = 0, getReceived = true, getSent = true) => __awaiter(this, void 0, void 0, function* () {
+            // Get all transactions encoded
             const encoded = yield __classPrivateFieldGet(this, _WebSDK_fetchTransactions, "f").call(this);
+            // Decode JWT payload to get raw transactions
             const { transactions } = yield (0, utils_1.decodeJWT)(encoded);
             let response = transactions;
+            // if getReceived is set to false, only get the transactions that have "senderUid"
             if (!getReceived)
                 response = transactions.filter((t) => { var _a; return t.receiverUid !== ((_a = this.user) === null || _a === void 0 ? void 0 : _a.uid); });
+            // if getSent is set to false, only get the transactions that have "receiverUid"
             if (!getSent)
                 response = transactions.filter((t) => { var _a; return t.senderUid !== ((_a = this.user) === null || _a === void 0 ? void 0 : _a.uid); });
+            // if quantity is set to higher than 0, only get the transaction quantity else we get all of them
             const limitTxs = quantity > 0 ? response.splice(0, quantity) : response.splice(0);
+            // map transactions to have a typed return object
             const txs = limitTxs.map((t) => {
                 return {
                     date: t.dateCreated || null,

--- a/dist/index.js
+++ b/dist/index.js
@@ -19,11 +19,12 @@ var __classPrivateFieldSet = (this && this.__classPrivateFieldSet) || function (
     if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot write private member to an object whose class did not declare it");
     return (kind === "a" ? f.call(receiver, value) : f ? f.value = value : state.set(receiver, value)), value;
 };
-var _WebSDK_environment, _WebSDK_oauth2Client, _WebSDK_wrappedDek, _WebSDK_domainDev, _WebSDK_audienceDev, _WebSDK_domainProd, _WebSDK_audienceProd, _WebSDK_domain, _WebSDK_audience, _WebSDK_pwaDevUrl, _WebSDK_pwaStagingUrl, _WebSDK_pwaProdUrl, _WebSDK_createRequest, _WebSDK_fetchUserBalances, _WebSDK_fetchUserWallets, _WebSDK_fetchUserInfo, _WebSDK_fetchUserNfts, _WebSDK_getWrappedDek;
+var _WebSDK_environment, _WebSDK_oauth2Client, _WebSDK_wrappedDek, _WebSDK_domainDev, _WebSDK_audienceDev, _WebSDK_domainProd, _WebSDK_audienceProd, _WebSDK_domain, _WebSDK_audience, _WebSDK_pwaDevUrl, _WebSDK_pwaStagingUrl, _WebSDK_pwaProdUrl, _WebSDK_createRequest, _WebSDK_fetchUserBalances, _WebSDK_fetchUserWallets, _WebSDK_fetchUserInfo, _WebSDK_fetchUserNfts, _WebSDK_getWrappedDek, _WebSDK_fetchTransactions;
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.LoginButton = exports.LoginBehavior = exports.SupportedChains = exports.SphereEnvironment = void 0;
 const types_1 = require("./src/types");
 const oidc_client_ts_1 = require("oidc-client-ts");
+const utils_1 = require("./src/utils");
 var types_2 = require("./src/types");
 Object.defineProperty(exports, "SphereEnvironment", { enumerable: true, get: function () { return types_2.Environments; } });
 var types_3 = require("./src/types");
@@ -310,6 +311,18 @@ class WebSDK {
                 return error;
             }
         }));
+        _WebSDK_fetchTransactions.set(this, () => __awaiter(this, void 0, void 0, function* () {
+            try {
+                const requestOptions = yield __classPrivateFieldGet(this, _WebSDK_createRequest, "f").call(this);
+                const response = yield fetch(`${this.baseUrl}/transactions`, requestOptions);
+                const data = yield response.json();
+                return data.data;
+            }
+            catch (error) {
+                console.error('There was an error getting transactions, error: ', error);
+                return error;
+            }
+        }));
         this.createCharge = (charge) => __awaiter(this, void 0, void 0, function* () {
             var _f;
             try {
@@ -355,6 +368,16 @@ class WebSDK {
                 console.error('There was an error paying this transaction, error: ', error);
                 return error;
             }
+        });
+        this.getTransactions = (quantity = 0, getReceived = true, getSent = true) => __awaiter(this, void 0, void 0, function* () {
+            const encoded = yield __classPrivateFieldGet(this, _WebSDK_fetchTransactions, "f").call(this);
+            const { transactions } = yield (0, utils_1.decodeJWT)(encoded);
+            let response = transactions;
+            if (!getReceived)
+                response = transactions.filter((t) => t.receiverUid === undefined);
+            if (!getSent)
+                response = transactions.filter((t) => t.senderUid === undefined);
+            return quantity > 0 ? response.splice(0, quantity) : response.splice(0);
         });
         this.getWallets = () => __awaiter(this, void 0, void 0, function* () {
             var _g;
@@ -403,6 +426,6 @@ class WebSDK {
         return iframe;
     }
 }
-_WebSDK_environment = new WeakMap(), _WebSDK_oauth2Client = new WeakMap(), _WebSDK_wrappedDek = new WeakMap(), _WebSDK_domainDev = new WeakMap(), _WebSDK_audienceDev = new WeakMap(), _WebSDK_domainProd = new WeakMap(), _WebSDK_audienceProd = new WeakMap(), _WebSDK_domain = new WeakMap(), _WebSDK_audience = new WeakMap(), _WebSDK_pwaDevUrl = new WeakMap(), _WebSDK_pwaStagingUrl = new WeakMap(), _WebSDK_pwaProdUrl = new WeakMap(), _WebSDK_createRequest = new WeakMap(), _WebSDK_fetchUserBalances = new WeakMap(), _WebSDK_fetchUserWallets = new WeakMap(), _WebSDK_fetchUserInfo = new WeakMap(), _WebSDK_fetchUserNfts = new WeakMap(), _WebSDK_getWrappedDek = new WeakMap();
+_WebSDK_environment = new WeakMap(), _WebSDK_oauth2Client = new WeakMap(), _WebSDK_wrappedDek = new WeakMap(), _WebSDK_domainDev = new WeakMap(), _WebSDK_audienceDev = new WeakMap(), _WebSDK_domainProd = new WeakMap(), _WebSDK_audienceProd = new WeakMap(), _WebSDK_domain = new WeakMap(), _WebSDK_audience = new WeakMap(), _WebSDK_pwaDevUrl = new WeakMap(), _WebSDK_pwaStagingUrl = new WeakMap(), _WebSDK_pwaProdUrl = new WeakMap(), _WebSDK_createRequest = new WeakMap(), _WebSDK_fetchUserBalances = new WeakMap(), _WebSDK_fetchUserWallets = new WeakMap(), _WebSDK_fetchUserInfo = new WeakMap(), _WebSDK_fetchUserNfts = new WeakMap(), _WebSDK_getWrappedDek = new WeakMap(), _WebSDK_fetchTransactions = new WeakMap();
 WebSDK.instance = undefined;
 exports.default = WebSDK;

--- a/dist/index.js
+++ b/dist/index.js
@@ -377,7 +377,23 @@ class WebSDK {
                 response = transactions.filter((t) => { var _a; return t.receiverUid !== ((_a = this.user) === null || _a === void 0 ? void 0 : _a.uid); });
             if (!getSent)
                 response = transactions.filter((t) => { var _a; return t.senderUid !== ((_a = this.user) === null || _a === void 0 ? void 0 : _a.uid); });
-            return quantity > 0 ? response.splice(0, quantity) : response.splice(0);
+            const limitTxs = quantity > 0 ? response.splice(0, quantity) : response.splice(0);
+            const txs = limitTxs.map((t) => {
+                return {
+                    date: t.dateCreated || null,
+                    toAddress: t.toAddress || null,
+                    chain: t.chain,
+                    symbol: t.symbol || t.commodity,
+                    amount: t.total || t.commodityAmount,
+                    tokenAddress: t.tokenAddress || null,
+                    nft: {
+                        img: t.itemInfo.imageUrl,
+                        name: t.itemInfo.name,
+                        address: t.address,
+                    }
+                };
+            });
+            return txs;
         });
         this.getWallets = () => __awaiter(this, void 0, void 0, function* () {
             var _g;

--- a/dist/index.js
+++ b/dist/index.js
@@ -374,9 +374,9 @@ class WebSDK {
             const { transactions } = yield (0, utils_1.decodeJWT)(encoded);
             let response = transactions;
             if (!getReceived)
-                response = transactions.filter((t) => t.receiverUid === undefined);
+                response = transactions.filter((t) => { var _a; return t.receiverUid !== ((_a = this.user) === null || _a === void 0 ? void 0 : _a.uid); });
             if (!getSent)
-                response = transactions.filter((t) => t.senderUid === undefined);
+                response = transactions.filter((t) => { var _a; return t.senderUid !== ((_a = this.user) === null || _a === void 0 ? void 0 : _a.uid); });
             return quantity > 0 ? response.splice(0, quantity) : response.splice(0);
         });
         this.getWallets = () => __awaiter(this, void 0, void 0, function* () {

--- a/dist/src/types.d.ts
+++ b/dist/src/types.d.ts
@@ -84,11 +84,13 @@ export interface Credentials {
     refreshToken?: string;
 }
 export interface Transaction {
+    date?: Date;
     toAddress: string;
     chain: SupportedChains;
     symbol: string;
     amount: number;
     tokenAddress: string;
+    nft?: NftsInfo;
 }
 export type NftsInfo = {
     img: string | undefined;

--- a/dist/src/utils.d.ts
+++ b/dist/src/utils.d.ts
@@ -1,0 +1,1 @@
+export declare function decodeJWT(data: string): Promise<any>;

--- a/dist/src/utils.js
+++ b/dist/src/utils.js
@@ -1,0 +1,23 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.decodeJWT = void 0;
+const jwt_decode_1 = __importDefault(require("jwt-decode"));
+function decodeJWT(data) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const decodeTransactions = (0, jwt_decode_1.default)(data);
+        return decodeTransactions;
+    });
+}
+exports.decodeJWT = decodeJWT;

--- a/index.ts
+++ b/index.ts
@@ -385,9 +385,9 @@ class WebSDK implements iWebSDK {
     const { transactions } = await decodeJWT(encoded)
     let response = transactions
     if (!getReceived) 
-      response = transactions.filter((t: any) => t.receiverUid === undefined)
+      response = transactions.filter((t: any) => t.receiverUid !== this.user?.uid)
     if (!getSent)
-      response = transactions.filter((t: any) => t.senderUid === undefined)
+      response = transactions.filter((t: any) => t.senderUid !== this.user?.uid)
 
     return quantity > 0 ? response.splice(0, quantity) : response.splice(0)
   }

--- a/index.ts
+++ b/index.ts
@@ -380,13 +380,22 @@ class WebSDK implements iWebSDK {
     getReceived = true,
     getSent = true
   ): Promise<Transaction[]> => {
+    // Get all transactions encoded
     const encoded = await this.#fetchTransactions();
+
+    // Decode JWT payload to get raw transactions
     const { transactions } = await decodeJWT(encoded);
     let response = transactions;
+
+    // if getReceived is set to false, only get the transactions that have "senderUid"
     if (!getReceived) response = transactions.filter((t: any) => t.receiverUid !== this.user?.uid);
+    // if getSent is set to false, only get the transactions that have "receiverUid"
     if (!getSent) response = transactions.filter((t: any) => t.senderUid !== this.user?.uid);
 
+    // if quantity is set to higher than 0, only get the transaction quantity else we get all of them
     const limitTxs = quantity > 0 ? response.splice(0, quantity) : response.splice(0);
+
+    // map transactions to have a typed return object
     const txs: Transaction[] = limitTxs.map((t: any) => {
       return {
         date: t.dateCreated || null,

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@types/react": "^18.2.20",
         "@types/react-dom": "^18.2.7",
+        "jwt-decode": "^3.1.2",
         "oidc-client-ts": "^2.2.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@types/react": "^18.2.20",
     "@types/react-dom": "^18.2.7",
+    "jwt-decode": "^3.1.2",
     "oidc-client-ts": "^2.2.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,11 +95,13 @@ export interface Credentials {
 }
 
 export interface Transaction {
+  date?: Date;
   toAddress: string;
   chain: SupportedChains;
   symbol: string;
   amount: number;
   tokenAddress: string;
+  nft?: NftsInfo
 }
 
 export type NftsInfo = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,6 @@
+import jwtDecode from "jwt-decode";
+
+export async function decodeJWT(data: string) {
+    const decodeTransactions = jwtDecode(data) as any;
+    return decodeTransactions;
+  }


### PR DESCRIPTION
### **PR Description**

Jira Ticket: [ENG-1651](https://sphereone.atlassian.net/browse/ENG-1651)

This PR includes some changes in the SDK to have a method to get the user transactions.

### **ChangeLogs**

- New `utils.ts` file containing a method to decode a payload in JWT format.
- New private method that uses the server endpoint to get the user transactions.
- New public method to fetch user transactions, includes optional parameters to fetch:
  - only sent transactions.
  - only received transactions.
  - get a predetermined number of transactions.

### **Designs**

`No designs`

### **Additional Notes**

This PR is related to [another PR on server repository](https://github.com/SphereGlobal/server/pull/500)




[ENG-1651]: https://sphereone.atlassian.net/browse/ENG-1651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ