### PR TITLE
feat: addWallet

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,4 +1,4 @@
-import { ChargeReqBody, UserInfo, LoginBehavior, NftsInfo, Transaction, User, Wallet, UserBalance, ChargeUrlAndId, PayResponseOnRampLink, PayResponseRouteCreated, PayErrorResponse, ForceRefresh } from './src/types';
+import { ChargeReqBody, UserInfo, LoginBehavior, NftsInfo, Transaction, User, Wallet, UserBalance, ChargeUrlAndId, PayResponseOnRampLink, PayResponseRouteCreated, PayErrorResponse, ForceRefresh, SupportedChains } from './src/types';
 export { Environments as SphereEnvironment } from './src/types';
 export { SupportedChains } from './src/types';
 export { LoginBehavior } from './src/types';
@@ -10,12 +10,19 @@ declare class WebSDK {
     private redirectUri;
     private apiKey;
     private loginType;
+    scope: string;
     constructor(clientId: string, redirectUri: string, apiKey: string, loginType?: LoginBehavior);
+    getAccessToken: () => string;
+    getIdToken: () => string;
     clear: () => void;
     handleCallback: () => Promise<any>;
     login: () => Promise<any>;
     logout: () => Promise<void>;
-    createCharge: (charge: ChargeReqBody) => Promise<ChargeUrlAndId>;
+    createCharge: ({ chargeData, isDirectTransfer, isTest, }: {
+        chargeData: ChargeReqBody;
+        isDirectTransfer?: boolean | undefined;
+        isTest?: boolean | undefined;
+    }) => Promise<ChargeUrlAndId>;
     pay: ({ toAddress, chain, symbol, amount, tokenAddress, }: Transaction) => Promise<PayResponseRouteCreated | PayResponseOnRampLink | PayErrorResponse>;
     payCharge: (transactionId: string) => Promise<PayResponseRouteCreated | PayResponseOnRampLink | PayErrorResponse>;
     getWallets: ({ forceRefresh }?: ForceRefresh) => Promise<Wallet[]>;
@@ -30,5 +37,13 @@ declare class WebSDK {
     }) => Promise<Transaction[]>;
     createIframe(width: number, height: number): HTMLIFrameElement;
     isTokenExpired: () => Promise<boolean>;
+    addWallet: ({ walletAddress, chains, label, }: {
+        walletAddress: string;
+        chains: SupportedChains[];
+        label?: string | undefined;
+    }) => Promise<{
+        data: string;
+        error: null;
+    }>;
 }
 export default WebSDK;

--- a/dist/src/types.d.ts
+++ b/dist/src/types.d.ts
@@ -88,7 +88,7 @@ export interface Credentials {
 }
 export interface LoadCredentialsParams {
     access_token: string;
-    idToken?: string;
+    id_token?: string;
     refresh_token?: string;
     expires_at?: number;
 }

--- a/index.ts
+++ b/index.ts
@@ -22,6 +22,7 @@ import {
   PayErrorResponse,
   LoadCredentialsParams,
   ForceRefresh,
+  SupportedChains,
 } from './src/types';
 import { UserManager, WebStorageStateStore } from 'oidc-client-ts';
 import { decodeJWT } from './src/utils';
@@ -46,6 +47,7 @@ class WebSDK {
   #audience: string = 'https://relaxed-kirch-zjpimqs5qe.projects.oryapis.com';
   #pwaProdUrl = 'https://wallet.sphereone.xyz';
   #baseUrl: string = 'https://api-olgsdff53q-uc.a.run.app';
+  scope: string = 'openid email offline_access profile';
 
   constructor(
     clientId: string,
@@ -67,10 +69,18 @@ class WebSDK {
         typeof window !== 'undefined'
           ? new WebStorageStateStore({ store: window.localStorage })
           : undefined,
-      scope: 'openid offline_access',
+      scope: this.scope,
       automaticSilentRenew: true,
     });
   }
+
+  getAccessToken = (): string => {
+    return this.#credentials?.accessToken ?? '';
+  };
+
+  getIdToken = (): string => {
+    return this.#credentials?.idToken ?? '';
+  };
 
   clear = () => {
     this.user = null;
@@ -78,10 +88,10 @@ class WebSDK {
     this.#wrappedDek = '';
   };
 
-  #loadCredentials({ access_token, idToken, refresh_token, expires_at }: LoadCredentialsParams) {
+  #loadCredentials({ access_token, id_token, refresh_token, expires_at }: LoadCredentialsParams) {
     this.#credentials = {
       accessToken: access_token,
-      idToken: idToken ?? '',
+      idToken: id_token ?? '',
       refreshToken: refresh_token,
       expires_at: expires_at ?? 0,
     };
@@ -103,11 +113,11 @@ class WebSDK {
       } else return null;
     } catch (error: any) {
       // this happens because it tries a login although there is no session/user
-      // this par is used with the login.Redirect
-      if (!error.message.includes('state'))
-        console.error('There was an error loggin, error: ', error);
-      this.user = null;
-      return error;
+      // this piece of code is used with the login.Redirect
+      if (error.message.includes('state')) {
+        return null;
+      }
+      throw new Error(error.message || JSON.stringify(error));
     }
   };
 
@@ -143,9 +153,10 @@ class WebSDK {
   handleCallback = async () => {
     try {
       const persistence = await this.#handlePersistence();
-      if (persistence) return persistence;
+      if (persistence) return { ...persistence, refresh_token: null };
       const handleAuth = await this.#handleAuth();
-      return handleAuth;
+      if (handleAuth) return { ...handleAuth, refresh_token: null };
+      else return null;
     } catch (error) {
       console.error('There was an error login, error: ', error);
       return error;
@@ -156,11 +167,13 @@ class WebSDK {
     if (this.loginType === LoginBehavior.REDIRECT) {
       await this.#oauth2Client?.signinRedirect({
         extraQueryParams: { audience: this.#audience },
+        scope: this.scope,
       });
     } else {
       try {
         const authResult = await this.#oauth2Client?.signinPopup({
           extraQueryParams: { audience: this.#audience },
+          scope: this.scope,
         });
         if (authResult) {
           this.#loadCredentials(authResult);
@@ -170,7 +183,7 @@ class WebSDK {
           // Load information in state
           this.#loadUserData();
 
-          return authResult;
+          return { ...authResult, refresh_token: null };
         } else return null;
       } catch (error: any) {
         console.error('There was an error logging inside login, error: ', error);
@@ -334,11 +347,19 @@ class WebSDK {
     }
   };
 
-  createCharge = async (charge: ChargeReqBody): Promise<ChargeUrlAndId> => {
+  createCharge = async ({
+    chargeData,
+    isDirectTransfer = false,
+    isTest = false,
+  }: {
+    chargeData: ChargeReqBody;
+    isDirectTransfer?: boolean;
+    isTest?: boolean;
+  }): Promise<ChargeUrlAndId> => {
     try {
       const requestOptions = await this.#createRequest(
         'POST',
-        { chargeData: charge },
+        { chargeData, isDirectTransfer, isTest },
         { 'x-api-key': this.apiKey ?? '' }
       );
 
@@ -537,6 +558,34 @@ class WebSDK {
     this.getBalances();
     this.getWallets();
   }
+
+  addWallet = async ({
+    walletAddress,
+    chains,
+    label,
+  }: {
+    walletAddress: string;
+    chains: SupportedChains[];
+    label?: string;
+  }): Promise<{ data: string; error: null }> => {
+    try {
+      if (!walletAddress || !chains)
+        throw new Error('Missing parameters, walletAddress and chains should be added');
+      const requestOptions = await this.#createRequest(
+        'POST',
+        { walletAddress, chains, label },
+        {
+          'x-api-key': this.apiKey,
+        }
+      );
+      const response = await fetch(`${this.#baseUrl}/addWallet`, requestOptions);
+      const data = await response.json();
+      return data;
+    } catch (error: any) {
+      console.error('There was an error adding a wallet, error: ', error);
+      throw new Error(error.message || error);
+    }
+  };
 }
 
 export default WebSDK;

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,7 +99,7 @@ export interface Credentials {
 
 export interface LoadCredentialsParams {
   access_token: string;
-  idToken?: string;
+  id_token?: string;
   refresh_token?: string;
   expires_at?: number;
 }


### PR DESCRIPTION
### **PR Description**

Added the `addWallet` functionality to the WebSdk so the developer can easily add wallets to the user document as read only. Also allowing access to the access token and id token but not to refresh token.  In the scopes 'profile' and 'email' was added. Also fixed the idToken reference in #loadCredentials.

### **Changelog**
- Added `addWallet` method 
- Added access to access token and id token
- Added email and profile to scopes.
- Add `isDirectTransfer` and `isTest` params to createCharge
- Fix `LoadCredentialsParams` interface
