### PR TITLE
Add optionality to don't perform hard refresh on logout, remove auth cookies before login, 

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -17,7 +17,7 @@ declare class WebSDK {
     clear: () => void;
     handleCallback: () => Promise<any>;
     login: () => Promise<any>;
-    logout: () => Promise<void>;
+    logout: (withPageReload?: boolean) => Promise<void>;
     createCharge: ({ chargeData, isDirectTransfer, isTest, }: {
         chargeData: ChargeReqBody;
         isDirectTransfer?: boolean | undefined;

--- a/dist/index.js
+++ b/dist/index.js
@@ -140,6 +140,7 @@ class WebSDK {
         });
         this.login = () => __awaiter(this, void 0, void 0, function* () {
             var _e, _f;
+            yield this.logout(false);
             if (this.loginType === types_1.LoginBehavior.REDIRECT) {
                 yield ((_e = __classPrivateFieldGet(this, _WebSDK_oauth2Client, "f")) === null || _e === void 0 ? void 0 : _e.signinRedirect({
                     extraQueryParams: { audience: __classPrivateFieldGet(this, _WebSDK_audience, "f") },
@@ -171,14 +172,14 @@ class WebSDK {
                 }
             }
         });
-        this.logout = () => __awaiter(this, void 0, void 0, function* () {
+        this.logout = (withPageReload = true) => __awaiter(this, void 0, void 0, function* () {
             var _g, _h;
             try {
                 if (typeof window === 'undefined')
                     return;
                 (_g = __classPrivateFieldGet(this, _WebSDK_oauth2Client, "f")) === null || _g === void 0 ? void 0 : _g.signoutSilent();
                 (_h = __classPrivateFieldGet(this, _WebSDK_oauth2Client, "f")) === null || _h === void 0 ? void 0 : _h.removeUser();
-                window.location.replace(this.redirectUri);
+                withPageReload && window.location.replace(this.redirectUri);
                 this.clear();
             }
             catch (e) {

--- a/index.ts
+++ b/index.ts
@@ -441,10 +441,10 @@ class WebSDK {
 
   getTransactions = async (
     props: {
-      quantity: number;
-      getReceived: boolean;
-      getSent: boolean;
-      forceRefresh: boolean;
+      quantity?: number;
+      getReceived?: boolean;
+      getSent?: boolean;
+      forceRefresh?: boolean;
     } = {
       quantity: 0,
       getReceived: true,

--- a/index.ts
+++ b/index.ts
@@ -164,6 +164,7 @@ class WebSDK {
   };
 
   login = async () => {
+    await this.logout(false);
     if (this.loginType === LoginBehavior.REDIRECT) {
       await this.#oauth2Client?.signinRedirect({
         extraQueryParams: { audience: this.#audience },
@@ -192,12 +193,12 @@ class WebSDK {
     }
   };
 
-  logout = async () => {
+  logout = async (withPageReload = true) => {
     try {
       if (typeof window === 'undefined') return;
       this.#oauth2Client?.signoutSilent();
       this.#oauth2Client?.removeUser();
-      window.location.replace(this.redirectUri as string);
+      withPageReload && window.location.replace(this.redirectUri as string);
       this.clear();
     } catch (e) {
       console.error('error logging out', e);


### PR DESCRIPTION
- Added a `withPageReload ` prop in the logout function set to true by default, if false, it won't refresh the page on logout
- Call the `logout` function with the `withPageReload ` prop set to false to remove the user auth data from the cookies before performing the login, this fixes a bug where if you try to login with another account without performing the logout first, will still return the credentials from the previous account because they weren't removed from local storage
- Made the props for `getTransactions` optional


These changes are live on https://test-web-sdk-git-nohardrefreshlogout-ephcratso.vercel.app/Games and were tested on the Qorbi World site.