### PR TITLE
Eng 1851  - WebSDK

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,19 +1,4 @@
-import {
-  ChargeReqBody,
-  UserInfo,
-  LoginBehavior,
-  NftsInfo,
-  Transaction,
-  User,
-  Wallet,
-  UserBalance,
-  ChargeUrlAndId,
-  PayResponseOnRampLink,
-  PayResponseRouteCreated,
-  PayErrorResponse,
-  ForceRefresh,
-  SupportedChains,
-} from './src/types';
+import { ChargeReqBody, UserInfo, LoginBehavior, NftsInfo, Transaction, User, Wallet, UserBalance, ChargeUrlAndId, PayResponseOnRampLink, PayResponseRouteCreated, PayErrorResponse, ForceRefresh, SupportedChains } from './src/types';
 export { Environments as SphereEnvironment } from './src/types';
 export { SupportedChains } from './src/types';
 export { LoginBehavior } from './src/types';

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,4 +1,4 @@
-import { ChargeReqBody, UserInfo, LoginBehavior, NftsInfo, Transaction, User, Wallet, UserBalance, ChargeUrlAndId, PayResponseRouteCreated, PayErrorResponse, ForceRefresh, SupportedChains, SDKPayResponseOnRampLink } from './src/types';
+import { ChargeReqBody, UserInfo, LoginBehavior, NftsInfo, Transaction, User, Wallet, UserBalance, ChargeUrlAndId, ForceRefresh, SupportedChains, PayResponse } from './src/types';
 export { Environments as SphereEnvironment } from './src/types';
 export { SupportedChains } from './src/types';
 export { LoginBehavior } from './src/types';
@@ -23,8 +23,8 @@ declare class WebSDK {
         isDirectTransfer?: boolean | undefined;
         isTest?: boolean | undefined;
     }) => Promise<ChargeUrlAndId>;
-    pay: ({ toAddress, chain, symbol, amount, tokenAddress, }: Transaction) => Promise<PayResponseRouteCreated | SDKPayResponseOnRampLink | PayErrorResponse>;
-    payCharge: (transactionId: string) => Promise<PayResponseRouteCreated | SDKPayResponseOnRampLink | PayErrorResponse>;
+    pay: ({ toAddress, chain, symbol, amount, tokenAddress, }: Transaction) => Promise<PayResponse>;
+    payCharge: (transactionId: string) => Promise<PayResponse>;
     getWallets: ({ forceRefresh }?: ForceRefresh) => Promise<Wallet[]>;
     getUserInfo: ({ forceRefresh }?: ForceRefresh) => Promise<UserInfo>;
     getBalances: ({ forceRefresh }?: ForceRefresh) => Promise<UserBalance>;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,4 +1,4 @@
-import { ChargeReqBody, UserInfo, LoginBehavior, NftsInfo, Transaction, User, Wallet, UserBalance, ChargeUrlAndId, PayResponseOnRampLink, PayResponseRouteCreated, PayErrorResponse, ForceRefresh, SupportedChains } from './src/types';
+import { ChargeReqBody, UserInfo, LoginBehavior, NftsInfo, Transaction, User, Wallet, UserBalance, ChargeUrlAndId, PayResponseRouteCreated, PayErrorResponse, ForceRefresh, SupportedChains, SDKPayResponseOnRampLink } from './src/types';
 export { Environments as SphereEnvironment } from './src/types';
 export { SupportedChains } from './src/types';
 export { LoginBehavior } from './src/types';
@@ -23,8 +23,8 @@ declare class WebSDK {
         isDirectTransfer?: boolean | undefined;
         isTest?: boolean | undefined;
     }) => Promise<ChargeUrlAndId>;
-    pay: ({ toAddress, chain, symbol, amount, tokenAddress, }: Transaction) => Promise<PayResponseRouteCreated | PayResponseOnRampLink | PayErrorResponse>;
-    payCharge: (transactionId: string) => Promise<PayResponseRouteCreated | PayResponseOnRampLink | PayErrorResponse>;
+    pay: ({ toAddress, chain, symbol, amount, tokenAddress, }: Transaction) => Promise<PayResponseRouteCreated | SDKPayResponseOnRampLink | PayErrorResponse>;
+    payCharge: (transactionId: string) => Promise<PayResponseRouteCreated | SDKPayResponseOnRampLink | PayErrorResponse>;
     getWallets: ({ forceRefresh }?: ForceRefresh) => Promise<Wallet[]>;
     getUserInfo: ({ forceRefresh }?: ForceRefresh) => Promise<UserInfo>;
     getBalances: ({ forceRefresh }?: ForceRefresh) => Promise<UserBalance>;

--- a/dist/index.js
+++ b/dist/index.js
@@ -357,26 +357,22 @@ class WebSDK {
                     tokenAddress,
                 });
                 const response = yield fetch(`${__classPrivateFieldGet(this, _WebSDK_baseUrl, "f")}/pay`, requestOptions);
-                const res = yield response.json();
-                if (res.error) {
-                    const onRampResponse = res;
-                    if (((_k = onRampResponse.error) === null || _k === void 0 ? void 0 : _k.code) === 'empty-balances' ||
-                        ((_l = onRampResponse.error) === null || _l === void 0 ? void 0 : _l.code) === 'insufficient-balances' ||
-                        ((_m = onRampResponse.error) === null || _m === void 0 ? void 0 : _m.message.includes('Not sufficient funds to bridge'))) {
-                        const onrampLink = (_o = onRampResponse.data) === null || _o === void 0 ? void 0 : _o.onrampLink;
+                const payResponse = yield response.json();
+                if (payResponse.error) {
+                    if (((_k = payResponse.error) === null || _k === void 0 ? void 0 : _k.code) === 'empty-balances' ||
+                        ((_l = payResponse.error) === null || _l === void 0 ? void 0 : _l.code) === 'insufficient-balances' ||
+                        ((_m = payResponse.error) === null || _m === void 0 ? void 0 : _m.message.includes('Not sufficient funds to bridge'))) {
                         return {
-                            data: { onrampLink, status: types_1.TxStatus.PENDING },
+                            data: Object.assign({}, payResponse.data),
                             error: 'insufficient balances',
                         };
                     }
                     else {
-                        const errorResponse = res;
-                        throw new Error(`Payment failed: ${errorResponse.error}`);
+                        return { data: null, error: ((_o = payResponse === null || payResponse === void 0 ? void 0 : payResponse.error) === null || _o === void 0 ? void 0 : _o.message) || (payResponse === null || payResponse === void 0 ? void 0 : payResponse.error) };
                     }
                 }
                 else {
-                    const payResponse = res;
-                    return { data: Object.assign({}, payResponse.data), error: null };
+                    return payResponse;
                 }
             }
             catch (error) {
@@ -392,31 +388,29 @@ class WebSDK {
                     throw new Error('There was an error getting the wrapped dek');
                 const requestOptions = yield __classPrivateFieldGet(this, _WebSDK_createRequest, "f").call(this, 'POST', { wrappedDek, transactionId });
                 const response = yield fetch(`${__classPrivateFieldGet(this, _WebSDK_baseUrl, "f")}/pay`, requestOptions);
-                const res = yield response.json();
-                if (res.error) {
-                    const onRampResponse = res;
-                    if (((_p = onRampResponse.error) === null || _p === void 0 ? void 0 : _p.code) === 'empty-balances' ||
-                        ((_q = onRampResponse.error) === null || _q === void 0 ? void 0 : _q.code) === 'insufficient-balances' ||
-                        ((_r = onRampResponse.error) === null || _r === void 0 ? void 0 : _r.message.includes('Not sufficient funds to bridge'))) {
-                        const onrampLink = (_s = onRampResponse.data) === null || _s === void 0 ? void 0 : _s.onrampLink;
+                const payResponse = yield response.json();
+                if (payResponse.error) {
+                    if (((_p = payResponse.error) === null || _p === void 0 ? void 0 : _p.code) === 'empty-balances' ||
+                        ((_q = payResponse.error) === null || _q === void 0 ? void 0 : _q.code) === 'insufficient-balances' ||
+                        ((_r = payResponse.error) === null || _r === void 0 ? void 0 : _r.message.includes('Not sufficient funds to bridge'))) {
                         return {
-                            data: { onrampLink, status: types_1.TxStatus.PENDING },
+                            data: Object.assign({}, payResponse.data),
                             error: 'insufficient balances',
                         };
                     }
                     else {
-                        const errorResponse = res;
-                        throw new Error(`Payment failed: ${errorResponse.error}`);
+                        return { data: null, error: ((_s = payResponse === null || payResponse === void 0 ? void 0 : payResponse.error) === null || _s === void 0 ? void 0 : _s.message) || (payResponse === null || payResponse === void 0 ? void 0 : payResponse.error) };
                     }
                 }
                 else {
-                    const payResponse = res;
-                    return { data: Object.assign({}, payResponse.data), error: null };
+                    console.log('payResponse', payResponse);
+                    debugger;
+                    return payResponse;
                 }
             }
             catch (error) {
                 console.error('There was an error paying this transaction, error: ', error);
-                throw new Error(error.message || error);
+                return { data: null, error: error.message || error };
             }
         });
         this.getWallets = ({ forceRefresh } = { forceRefresh: false }) => __awaiter(this, void 0, void 0, function* () { var _t; return __classPrivateFieldGet(this, _WebSDK_getData, "f").call(this, __classPrivateFieldGet(this, _WebSDK_fetchUserWallets, "f"), (_t = this.user) === null || _t === void 0 ? void 0 : _t.wallets, forceRefresh); });

--- a/dist/index.js
+++ b/dist/index.js
@@ -323,11 +323,8 @@ class WebSDK {
         this.createCharge = ({ chargeData, isDirectTransfer = false, isTest = false, }) => __awaiter(this, void 0, void 0, function* () {
             try {
                 // this endpoint doesn't need to have an a valid access token as header
-                const myHeaders = new Headers();
-                myHeaders.append('Content-Type', 'application/json');
-                myHeaders.append('x-api-key', this.apiKey);
                 const response = yield fetch(`${__classPrivateFieldGet(this, _WebSDK_baseUrl, "f")}/createCharge`, {
-                    headers: Object.assign({}, myHeaders),
+                    headers: { 'x-api-key': this.apiKey, 'Content-Type': 'application/json' },
                     method: 'POST',
                     body: JSON.stringify({
                         chargeData,
@@ -346,6 +343,7 @@ class WebSDK {
             }
         });
         this.pay = ({ toAddress, chain, symbol, amount, tokenAddress, }) => __awaiter(this, void 0, void 0, function* () {
+            var _k, _l, _m, _o;
             try {
                 const wrappedDek = yield __classPrivateFieldGet(this, _WebSDK_getWrappedDek, "f").call(this);
                 if (!wrappedDek)
@@ -359,7 +357,27 @@ class WebSDK {
                     tokenAddress,
                 });
                 const response = yield fetch(`${__classPrivateFieldGet(this, _WebSDK_baseUrl, "f")}/pay`, requestOptions);
-                return (yield response.json());
+                const res = yield response.json();
+                if (res.error) {
+                    const onRampResponse = res;
+                    if (((_k = onRampResponse.error) === null || _k === void 0 ? void 0 : _k.code) === 'empty-balances' ||
+                        ((_l = onRampResponse.error) === null || _l === void 0 ? void 0 : _l.code) === 'insufficient-balances' ||
+                        ((_m = onRampResponse.error) === null || _m === void 0 ? void 0 : _m.message.includes('Not sufficient funds to bridge'))) {
+                        const onrampLink = (_o = onRampResponse.data) === null || _o === void 0 ? void 0 : _o.onrampLink;
+                        return {
+                            data: { onrampLink, status: types_1.TxStatus.PENDING },
+                            error: 'insufficient balances',
+                        };
+                    }
+                    else {
+                        const errorResponse = res;
+                        throw new Error(`Payment failed: ${errorResponse.error}`);
+                    }
+                }
+                else {
+                    const payResponse = res;
+                    return { data: Object.assign({}, payResponse.data), error: null };
+                }
             }
             catch (error) {
                 console.error('There was an processing your payment, error: ', error);
@@ -367,30 +385,51 @@ class WebSDK {
             }
         });
         this.payCharge = (transactionId) => __awaiter(this, void 0, void 0, function* () {
+            var _p, _q, _r, _s;
             try {
                 const wrappedDek = yield __classPrivateFieldGet(this, _WebSDK_getWrappedDek, "f").call(this);
                 if (!wrappedDek)
                     throw new Error('There was an error getting the wrapped dek');
                 const requestOptions = yield __classPrivateFieldGet(this, _WebSDK_createRequest, "f").call(this, 'POST', { wrappedDek, transactionId });
                 const response = yield fetch(`${__classPrivateFieldGet(this, _WebSDK_baseUrl, "f")}/pay`, requestOptions);
-                return (yield response.json());
+                const res = yield response.json();
+                if (res.error) {
+                    const onRampResponse = res;
+                    if (((_p = onRampResponse.error) === null || _p === void 0 ? void 0 : _p.code) === 'empty-balances' ||
+                        ((_q = onRampResponse.error) === null || _q === void 0 ? void 0 : _q.code) === 'insufficient-balances' ||
+                        ((_r = onRampResponse.error) === null || _r === void 0 ? void 0 : _r.message.includes('Not sufficient funds to bridge'))) {
+                        const onrampLink = (_s = onRampResponse.data) === null || _s === void 0 ? void 0 : _s.onrampLink;
+                        return {
+                            data: { onrampLink, status: types_1.TxStatus.PENDING },
+                            error: 'insufficient balances',
+                        };
+                    }
+                    else {
+                        const errorResponse = res;
+                        throw new Error(`Payment failed: ${errorResponse.error}`);
+                    }
+                }
+                else {
+                    const payResponse = res;
+                    return { data: Object.assign({}, payResponse.data), error: null };
+                }
             }
             catch (error) {
                 console.error('There was an error paying this transaction, error: ', error);
                 throw new Error(error.message || error);
             }
         });
-        this.getWallets = ({ forceRefresh } = { forceRefresh: false }) => __awaiter(this, void 0, void 0, function* () { var _k; return __classPrivateFieldGet(this, _WebSDK_getData, "f").call(this, __classPrivateFieldGet(this, _WebSDK_fetchUserWallets, "f"), (_k = this.user) === null || _k === void 0 ? void 0 : _k.wallets, forceRefresh); });
-        this.getUserInfo = ({ forceRefresh } = { forceRefresh: false }) => __awaiter(this, void 0, void 0, function* () { var _l; return __classPrivateFieldGet(this, _WebSDK_getData, "f").call(this, __classPrivateFieldGet(this, _WebSDK_fetchUserInfo, "f"), (_l = this.user) === null || _l === void 0 ? void 0 : _l.info, forceRefresh); });
-        this.getBalances = ({ forceRefresh } = { forceRefresh: false }) => __awaiter(this, void 0, void 0, function* () { var _m; return __classPrivateFieldGet(this, _WebSDK_getData, "f").call(this, __classPrivateFieldGet(this, _WebSDK_fetchUserBalances, "f"), (_m = this.user) === null || _m === void 0 ? void 0 : _m.balances, forceRefresh); });
-        this.getNfts = ({ forceRefresh } = { forceRefresh: false }) => __awaiter(this, void 0, void 0, function* () { var _o; return __classPrivateFieldGet(this, _WebSDK_getData, "f").call(this, __classPrivateFieldGet(this, _WebSDK_fetchUserNfts, "f"), (_o = this.user) === null || _o === void 0 ? void 0 : _o.nfts, forceRefresh); });
+        this.getWallets = ({ forceRefresh } = { forceRefresh: false }) => __awaiter(this, void 0, void 0, function* () { var _t; return __classPrivateFieldGet(this, _WebSDK_getData, "f").call(this, __classPrivateFieldGet(this, _WebSDK_fetchUserWallets, "f"), (_t = this.user) === null || _t === void 0 ? void 0 : _t.wallets, forceRefresh); });
+        this.getUserInfo = ({ forceRefresh } = { forceRefresh: false }) => __awaiter(this, void 0, void 0, function* () { var _u; return __classPrivateFieldGet(this, _WebSDK_getData, "f").call(this, __classPrivateFieldGet(this, _WebSDK_fetchUserInfo, "f"), (_u = this.user) === null || _u === void 0 ? void 0 : _u.info, forceRefresh); });
+        this.getBalances = ({ forceRefresh } = { forceRefresh: false }) => __awaiter(this, void 0, void 0, function* () { var _v; return __classPrivateFieldGet(this, _WebSDK_getData, "f").call(this, __classPrivateFieldGet(this, _WebSDK_fetchUserBalances, "f"), (_v = this.user) === null || _v === void 0 ? void 0 : _v.balances, forceRefresh); });
+        this.getNfts = ({ forceRefresh } = { forceRefresh: false }) => __awaiter(this, void 0, void 0, function* () { var _w; return __classPrivateFieldGet(this, _WebSDK_getData, "f").call(this, __classPrivateFieldGet(this, _WebSDK_fetchUserNfts, "f"), (_w = this.user) === null || _w === void 0 ? void 0 : _w.nfts, forceRefresh); });
         this.getTransactions = (props = {
             quantity: 0,
             getReceived: true,
             getSent: true,
             forceRefresh: false,
         }) => __awaiter(this, void 0, void 0, function* () {
-            var _p;
+            var _x;
             // Get all transactions encoded
             let { quantity, getReceived, getSent, forceRefresh } = props;
             if (quantity === undefined)
@@ -401,7 +440,7 @@ class WebSDK {
                 getSent = true;
             if (forceRefresh === undefined)
                 forceRefresh = false;
-            const encoded = yield __classPrivateFieldGet(this, _WebSDK_getData, "f").call(this, __classPrivateFieldGet(this, _WebSDK_fetchTransactions, "f"), (_p = this.user) === null || _p === void 0 ? void 0 : _p.transactions, forceRefresh);
+            const encoded = yield __classPrivateFieldGet(this, _WebSDK_getData, "f").call(this, __classPrivateFieldGet(this, _WebSDK_fetchTransactions, "f"), (_x = this.user) === null || _x === void 0 ? void 0 : _x.transactions, forceRefresh);
             if (!encoded)
                 throw new Error("Couldn't get transactions");
             // Decode JWT payload to get raw transactions
@@ -435,32 +474,32 @@ class WebSDK {
             return txs;
         });
         this.isTokenExpired = () => __awaiter(this, void 0, void 0, function* () {
-            var _q, _r;
+            var _y, _z;
             if (!__classPrivateFieldGet(this, _WebSDK_credentials, "f")) {
-                const user = yield ((_q = __classPrivateFieldGet(this, _WebSDK_oauth2Client, "f")) === null || _q === void 0 ? void 0 : _q.getUser());
+                const user = yield ((_y = __classPrivateFieldGet(this, _WebSDK_oauth2Client, "f")) === null || _y === void 0 ? void 0 : _y.getUser());
                 if (user) {
                     return user.expires_at ? user.expires_at < Math.floor(Date.now() / 1000) : true;
                 }
                 else
                     return true;
             }
-            return ((_r = __classPrivateFieldGet(this, _WebSDK_credentials, "f")) === null || _r === void 0 ? void 0 : _r.expires_at)
+            return ((_z = __classPrivateFieldGet(this, _WebSDK_credentials, "f")) === null || _z === void 0 ? void 0 : _z.expires_at)
                 ? __classPrivateFieldGet(this, _WebSDK_credentials, "f").expires_at < Math.floor(Date.now() / 1000)
                 : true;
         });
         _WebSDK_refreshToken.set(this, () => __awaiter(this, void 0, void 0, function* () {
-            var _s, _t, _u, _v, _w, _x;
+            var _0, _1, _2, _3, _4, _5;
             try {
-                const user = yield ((_s = __classPrivateFieldGet(this, _WebSDK_oauth2Client, "f")) === null || _s === void 0 ? void 0 : _s.getUser());
-                if (((_t = __classPrivateFieldGet(this, _WebSDK_credentials, "f")) === null || _t === void 0 ? void 0 : _t.expires_at) &&
-                    ((_u = __classPrivateFieldGet(this, _WebSDK_credentials, "f")) === null || _u === void 0 ? void 0 : _u.expires_at) > Math.floor(Date.now() / 1000)) {
+                const user = yield ((_0 = __classPrivateFieldGet(this, _WebSDK_oauth2Client, "f")) === null || _0 === void 0 ? void 0 : _0.getUser());
+                if (((_1 = __classPrivateFieldGet(this, _WebSDK_credentials, "f")) === null || _1 === void 0 ? void 0 : _1.expires_at) &&
+                    ((_2 = __classPrivateFieldGet(this, _WebSDK_credentials, "f")) === null || _2 === void 0 ? void 0 : _2.expires_at) > Math.floor(Date.now() / 1000)) {
                     return user;
                 }
-                if (!((_v = __classPrivateFieldGet(this, _WebSDK_credentials, "f")) === null || _v === void 0 ? void 0 : _v.refreshToken) && user) {
+                if (!((_3 = __classPrivateFieldGet(this, _WebSDK_credentials, "f")) === null || _3 === void 0 ? void 0 : _3.refreshToken) && user) {
                     __classPrivateFieldGet(this, _WebSDK_instances, "m", _WebSDK_loadCredentials).call(this, user);
                 }
-                if ((_w = __classPrivateFieldGet(this, _WebSDK_credentials, "f")) === null || _w === void 0 ? void 0 : _w.refreshToken) {
-                    const userRefreshed = yield ((_x = __classPrivateFieldGet(this, _WebSDK_oauth2Client, "f")) === null || _x === void 0 ? void 0 : _x.signinSilent());
+                if ((_4 = __classPrivateFieldGet(this, _WebSDK_credentials, "f")) === null || _4 === void 0 ? void 0 : _4.refreshToken) {
+                    const userRefreshed = yield ((_5 = __classPrivateFieldGet(this, _WebSDK_oauth2Client, "f")) === null || _5 === void 0 ? void 0 : _5.signinSilent());
                     if (userRefreshed) {
                         __classPrivateFieldGet(this, _WebSDK_instances, "m", _WebSDK_loadCredentials).call(this, userRefreshed);
                         return userRefreshed;

--- a/dist/index.js
+++ b/dist/index.js
@@ -321,10 +321,20 @@ class WebSDK {
             }
         }));
         this.createCharge = ({ chargeData, isDirectTransfer = false, isTest = false, }) => __awaiter(this, void 0, void 0, function* () {
-            var _k;
             try {
-                const requestOptions = yield __classPrivateFieldGet(this, _WebSDK_createRequest, "f").call(this, 'POST', { chargeData, isDirectTransfer, isTest }, { 'x-api-key': (_k = this.apiKey) !== null && _k !== void 0 ? _k : '' });
-                const response = yield fetch(`${__classPrivateFieldGet(this, _WebSDK_baseUrl, "f")}/createCharge`, requestOptions);
+                // this endpoint doesn't need to have an a valid access token as header
+                const myHeaders = new Headers();
+                myHeaders.append('Content-Type', 'application/json');
+                myHeaders.append('x-api-key', this.apiKey);
+                const response = yield fetch(`${__classPrivateFieldGet(this, _WebSDK_baseUrl, "f")}/createCharge`, {
+                    headers: Object.assign({}, myHeaders),
+                    method: 'POST',
+                    body: JSON.stringify({
+                        chargeData,
+                        isDirectTransfer,
+                        isTest,
+                    }),
+                });
                 const data = (yield response.json());
                 if (data.error)
                     throw new Error(data.error);
@@ -370,17 +380,17 @@ class WebSDK {
                 throw new Error(error.message || error);
             }
         });
-        this.getWallets = ({ forceRefresh } = { forceRefresh: false }) => __awaiter(this, void 0, void 0, function* () { var _l; return __classPrivateFieldGet(this, _WebSDK_getData, "f").call(this, __classPrivateFieldGet(this, _WebSDK_fetchUserWallets, "f"), (_l = this.user) === null || _l === void 0 ? void 0 : _l.wallets, forceRefresh); });
-        this.getUserInfo = ({ forceRefresh } = { forceRefresh: false }) => __awaiter(this, void 0, void 0, function* () { var _m; return __classPrivateFieldGet(this, _WebSDK_getData, "f").call(this, __classPrivateFieldGet(this, _WebSDK_fetchUserInfo, "f"), (_m = this.user) === null || _m === void 0 ? void 0 : _m.info, forceRefresh); });
-        this.getBalances = ({ forceRefresh } = { forceRefresh: false }) => __awaiter(this, void 0, void 0, function* () { var _o; return __classPrivateFieldGet(this, _WebSDK_getData, "f").call(this, __classPrivateFieldGet(this, _WebSDK_fetchUserBalances, "f"), (_o = this.user) === null || _o === void 0 ? void 0 : _o.balances, forceRefresh); });
-        this.getNfts = ({ forceRefresh } = { forceRefresh: false }) => __awaiter(this, void 0, void 0, function* () { var _p; return __classPrivateFieldGet(this, _WebSDK_getData, "f").call(this, __classPrivateFieldGet(this, _WebSDK_fetchUserNfts, "f"), (_p = this.user) === null || _p === void 0 ? void 0 : _p.nfts, forceRefresh); });
+        this.getWallets = ({ forceRefresh } = { forceRefresh: false }) => __awaiter(this, void 0, void 0, function* () { var _k; return __classPrivateFieldGet(this, _WebSDK_getData, "f").call(this, __classPrivateFieldGet(this, _WebSDK_fetchUserWallets, "f"), (_k = this.user) === null || _k === void 0 ? void 0 : _k.wallets, forceRefresh); });
+        this.getUserInfo = ({ forceRefresh } = { forceRefresh: false }) => __awaiter(this, void 0, void 0, function* () { var _l; return __classPrivateFieldGet(this, _WebSDK_getData, "f").call(this, __classPrivateFieldGet(this, _WebSDK_fetchUserInfo, "f"), (_l = this.user) === null || _l === void 0 ? void 0 : _l.info, forceRefresh); });
+        this.getBalances = ({ forceRefresh } = { forceRefresh: false }) => __awaiter(this, void 0, void 0, function* () { var _m; return __classPrivateFieldGet(this, _WebSDK_getData, "f").call(this, __classPrivateFieldGet(this, _WebSDK_fetchUserBalances, "f"), (_m = this.user) === null || _m === void 0 ? void 0 : _m.balances, forceRefresh); });
+        this.getNfts = ({ forceRefresh } = { forceRefresh: false }) => __awaiter(this, void 0, void 0, function* () { var _o; return __classPrivateFieldGet(this, _WebSDK_getData, "f").call(this, __classPrivateFieldGet(this, _WebSDK_fetchUserNfts, "f"), (_o = this.user) === null || _o === void 0 ? void 0 : _o.nfts, forceRefresh); });
         this.getTransactions = (props = {
             quantity: 0,
             getReceived: true,
             getSent: true,
             forceRefresh: false,
         }) => __awaiter(this, void 0, void 0, function* () {
-            var _q;
+            var _p;
             // Get all transactions encoded
             let { quantity, getReceived, getSent, forceRefresh } = props;
             if (quantity === undefined)
@@ -391,7 +401,7 @@ class WebSDK {
                 getSent = true;
             if (forceRefresh === undefined)
                 forceRefresh = false;
-            const encoded = yield __classPrivateFieldGet(this, _WebSDK_getData, "f").call(this, __classPrivateFieldGet(this, _WebSDK_fetchTransactions, "f"), (_q = this.user) === null || _q === void 0 ? void 0 : _q.transactions, forceRefresh);
+            const encoded = yield __classPrivateFieldGet(this, _WebSDK_getData, "f").call(this, __classPrivateFieldGet(this, _WebSDK_fetchTransactions, "f"), (_p = this.user) === null || _p === void 0 ? void 0 : _p.transactions, forceRefresh);
             if (!encoded)
                 throw new Error("Couldn't get transactions");
             // Decode JWT payload to get raw transactions
@@ -425,32 +435,32 @@ class WebSDK {
             return txs;
         });
         this.isTokenExpired = () => __awaiter(this, void 0, void 0, function* () {
-            var _r, _s;
+            var _q, _r;
             if (!__classPrivateFieldGet(this, _WebSDK_credentials, "f")) {
-                const user = yield ((_r = __classPrivateFieldGet(this, _WebSDK_oauth2Client, "f")) === null || _r === void 0 ? void 0 : _r.getUser());
+                const user = yield ((_q = __classPrivateFieldGet(this, _WebSDK_oauth2Client, "f")) === null || _q === void 0 ? void 0 : _q.getUser());
                 if (user) {
                     return user.expires_at ? user.expires_at < Math.floor(Date.now() / 1000) : true;
                 }
                 else
                     return true;
             }
-            return ((_s = __classPrivateFieldGet(this, _WebSDK_credentials, "f")) === null || _s === void 0 ? void 0 : _s.expires_at)
+            return ((_r = __classPrivateFieldGet(this, _WebSDK_credentials, "f")) === null || _r === void 0 ? void 0 : _r.expires_at)
                 ? __classPrivateFieldGet(this, _WebSDK_credentials, "f").expires_at < Math.floor(Date.now() / 1000)
                 : true;
         });
         _WebSDK_refreshToken.set(this, () => __awaiter(this, void 0, void 0, function* () {
-            var _t, _u, _v, _w, _x, _y;
+            var _s, _t, _u, _v, _w, _x;
             try {
-                const user = yield ((_t = __classPrivateFieldGet(this, _WebSDK_oauth2Client, "f")) === null || _t === void 0 ? void 0 : _t.getUser());
-                if (((_u = __classPrivateFieldGet(this, _WebSDK_credentials, "f")) === null || _u === void 0 ? void 0 : _u.expires_at) &&
-                    ((_v = __classPrivateFieldGet(this, _WebSDK_credentials, "f")) === null || _v === void 0 ? void 0 : _v.expires_at) > Math.floor(Date.now() / 1000)) {
+                const user = yield ((_s = __classPrivateFieldGet(this, _WebSDK_oauth2Client, "f")) === null || _s === void 0 ? void 0 : _s.getUser());
+                if (((_t = __classPrivateFieldGet(this, _WebSDK_credentials, "f")) === null || _t === void 0 ? void 0 : _t.expires_at) &&
+                    ((_u = __classPrivateFieldGet(this, _WebSDK_credentials, "f")) === null || _u === void 0 ? void 0 : _u.expires_at) > Math.floor(Date.now() / 1000)) {
                     return user;
                 }
-                if (!((_w = __classPrivateFieldGet(this, _WebSDK_credentials, "f")) === null || _w === void 0 ? void 0 : _w.refreshToken) && user) {
+                if (!((_v = __classPrivateFieldGet(this, _WebSDK_credentials, "f")) === null || _v === void 0 ? void 0 : _v.refreshToken) && user) {
                     __classPrivateFieldGet(this, _WebSDK_instances, "m", _WebSDK_loadCredentials).call(this, user);
                 }
-                if ((_x = __classPrivateFieldGet(this, _WebSDK_credentials, "f")) === null || _x === void 0 ? void 0 : _x.refreshToken) {
-                    const userRefreshed = yield ((_y = __classPrivateFieldGet(this, _WebSDK_oauth2Client, "f")) === null || _y === void 0 ? void 0 : _y.signinSilent());
+                if ((_w = __classPrivateFieldGet(this, _WebSDK_credentials, "f")) === null || _w === void 0 ? void 0 : _w.refreshToken) {
+                    const userRefreshed = yield ((_x = __classPrivateFieldGet(this, _WebSDK_oauth2Client, "f")) === null || _x === void 0 ? void 0 : _x.signinSilent());
                     if (userRefreshed) {
                         __classPrivateFieldGet(this, _WebSDK_instances, "m", _WebSDK_loadCredentials).call(this, userRefreshed);
                         return userRefreshed;

--- a/dist/index.js
+++ b/dist/index.js
@@ -403,7 +403,6 @@ class WebSDK {
                     }
                 }
                 else {
-                    console.log('payResponse', payResponse);
                     debugger;
                     return payResponse;
                 }
@@ -434,6 +433,8 @@ class WebSDK {
                 getSent = true;
             if (forceRefresh === undefined)
                 forceRefresh = false;
+            if (!getSent && !getReceived)
+                throw new Error('getSent and getReceived cannot be both false');
             const encoded = yield __classPrivateFieldGet(this, _WebSDK_getData, "f").call(this, __classPrivateFieldGet(this, _WebSDK_fetchTransactions, "f"), (_x = this.user) === null || _x === void 0 ? void 0 : _x.transactions, forceRefresh);
             if (!encoded)
                 throw new Error("Couldn't get transactions");

--- a/dist/index.js
+++ b/dist/index.js
@@ -357,27 +357,35 @@ class WebSDK {
                     tokenAddress,
                 });
                 const response = yield fetch(`${__classPrivateFieldGet(this, _WebSDK_baseUrl, "f")}/pay`, requestOptions);
-                const payResponse = yield response.json();
-                if (payResponse.error) {
-                    if (((_k = payResponse.error) === null || _k === void 0 ? void 0 : _k.code) === 'empty-balances' ||
-                        ((_l = payResponse.error) === null || _l === void 0 ? void 0 : _l.code) === 'insufficient-balances' ||
-                        ((_m = payResponse.error) === null || _m === void 0 ? void 0 : _m.message.includes('Not sufficient funds to bridge'))) {
-                        return {
-                            data: Object.assign({}, payResponse.data),
-                            error: 'insufficient balances',
-                        };
+                const res = yield response.json();
+                if (res.error) {
+                    const onRampResponse = res;
+                    if (((_k = onRampResponse.error) === null || _k === void 0 ? void 0 : _k.code) === 'empty-balances' ||
+                        ((_l = onRampResponse.error) === null || _l === void 0 ? void 0 : _l.code) === 'insufficient-balances' ||
+                        ((_m = onRampResponse.error) === null || _m === void 0 ? void 0 : _m.message.includes('Not sufficient funds to bridge'))) {
+                        const onrampLink = (_o = onRampResponse.data) === null || _o === void 0 ? void 0 : _o.onrampLink;
+                        throw new types_1.PayError({
+                            message: 'insufficient balances',
+                            onrampLink: onrampLink,
+                        });
                     }
                     else {
-                        return { data: null, error: ((_o = payResponse === null || payResponse === void 0 ? void 0 : payResponse.error) === null || _o === void 0 ? void 0 : _o.message) || (payResponse === null || payResponse === void 0 ? void 0 : payResponse.error) };
+                        const errorResponse = res;
+                        throw new Error(`Payment failed: ${errorResponse.error}`);
                     }
                 }
                 else {
-                    return payResponse;
+                    const payResponse = res.data;
+                    return Object.assign({}, payResponse);
                 }
             }
             catch (error) {
-                console.error('There was an processing your payment, error: ', error);
-                throw new Error(error.message || error);
+                console.error('There was an error paying this transaction, error: ', error);
+                if (error instanceof types_1.PayError) {
+                    throw error;
+                }
+                else
+                    throw new Error(error);
             }
         });
         this.payCharge = (transactionId) => __awaiter(this, void 0, void 0, function* () {
@@ -388,28 +396,35 @@ class WebSDK {
                     throw new Error('There was an error getting the wrapped dek');
                 const requestOptions = yield __classPrivateFieldGet(this, _WebSDK_createRequest, "f").call(this, 'POST', { wrappedDek, transactionId });
                 const response = yield fetch(`${__classPrivateFieldGet(this, _WebSDK_baseUrl, "f")}/pay`, requestOptions);
-                const payResponse = yield response.json();
-                if (payResponse.error) {
-                    if (((_p = payResponse.error) === null || _p === void 0 ? void 0 : _p.code) === 'empty-balances' ||
-                        ((_q = payResponse.error) === null || _q === void 0 ? void 0 : _q.code) === 'insufficient-balances' ||
-                        ((_r = payResponse.error) === null || _r === void 0 ? void 0 : _r.message.includes('Not sufficient funds to bridge'))) {
-                        return {
-                            data: Object.assign({}, payResponse.data),
-                            error: 'insufficient balances',
-                        };
+                const res = yield response.json();
+                if (res.error) {
+                    const onRampResponse = res;
+                    if (((_p = onRampResponse.error) === null || _p === void 0 ? void 0 : _p.code) === 'empty-balances' ||
+                        ((_q = onRampResponse.error) === null || _q === void 0 ? void 0 : _q.code) === 'insufficient-balances' ||
+                        ((_r = onRampResponse.error) === null || _r === void 0 ? void 0 : _r.message.includes('Not sufficient funds to bridge'))) {
+                        const onrampLink = (_s = onRampResponse.data) === null || _s === void 0 ? void 0 : _s.onrampLink;
+                        throw new types_1.PayError({
+                            message: 'insufficient balances',
+                            onrampLink: onrampLink,
+                        });
                     }
                     else {
-                        return { data: null, error: ((_s = payResponse === null || payResponse === void 0 ? void 0 : payResponse.error) === null || _s === void 0 ? void 0 : _s.message) || (payResponse === null || payResponse === void 0 ? void 0 : payResponse.error) };
+                        const errorResponse = res;
+                        throw new Error(`Payment failed: ${errorResponse.error}`);
                     }
                 }
                 else {
-                    debugger;
-                    return payResponse;
+                    const payResponse = res.data;
+                    return Object.assign({}, payResponse);
                 }
             }
             catch (error) {
                 console.error('There was an error paying this transaction, error: ', error);
-                return { data: null, error: error.message || error };
+                if (error instanceof types_1.PayError) {
+                    throw error;
+                }
+                else
+                    throw new Error(error);
             }
         });
         this.getWallets = ({ forceRefresh } = { forceRefresh: false }) => __awaiter(this, void 0, void 0, function* () { var _t; return __classPrivateFieldGet(this, _WebSDK_getData, "f").call(this, __classPrivateFieldGet(this, _WebSDK_fetchUserWallets, "f"), (_t = this.user) === null || _t === void 0 ? void 0 : _t.wallets, forceRefresh); });

--- a/dist/index.js
+++ b/dist/index.js
@@ -389,7 +389,7 @@ class WebSDK {
             }
         });
         this.payCharge = (transactionId) => __awaiter(this, void 0, void 0, function* () {
-            var _p, _q, _r, _s;
+            var _p, _q, _r, _s, _t;
             try {
                 const wrappedDek = yield __classPrivateFieldGet(this, _WebSDK_getWrappedDek, "f").call(this);
                 if (!wrappedDek)
@@ -401,8 +401,8 @@ class WebSDK {
                     const onRampResponse = res;
                     if (((_p = onRampResponse.error) === null || _p === void 0 ? void 0 : _p.code) === 'empty-balances' ||
                         ((_q = onRampResponse.error) === null || _q === void 0 ? void 0 : _q.code) === 'insufficient-balances' ||
-                        ((_r = onRampResponse.error) === null || _r === void 0 ? void 0 : _r.message.includes('Not sufficient funds to bridge'))) {
-                        const onrampLink = (_s = onRampResponse.data) === null || _s === void 0 ? void 0 : _s.onrampLink;
+                        ((_s = (_r = onRampResponse.error) === null || _r === void 0 ? void 0 : _r.message) === null || _s === void 0 ? void 0 : _s.includes('Not sufficient funds to bridge'))) {
+                        const onrampLink = (_t = onRampResponse.data) === null || _t === void 0 ? void 0 : _t.onrampLink;
                         throw new types_1.PayError({
                             message: 'insufficient balances',
                             onrampLink: onrampLink,
@@ -427,17 +427,17 @@ class WebSDK {
                     throw new Error(error);
             }
         });
-        this.getWallets = ({ forceRefresh } = { forceRefresh: false }) => __awaiter(this, void 0, void 0, function* () { var _t; return __classPrivateFieldGet(this, _WebSDK_getData, "f").call(this, __classPrivateFieldGet(this, _WebSDK_fetchUserWallets, "f"), (_t = this.user) === null || _t === void 0 ? void 0 : _t.wallets, forceRefresh); });
-        this.getUserInfo = ({ forceRefresh } = { forceRefresh: false }) => __awaiter(this, void 0, void 0, function* () { var _u; return __classPrivateFieldGet(this, _WebSDK_getData, "f").call(this, __classPrivateFieldGet(this, _WebSDK_fetchUserInfo, "f"), (_u = this.user) === null || _u === void 0 ? void 0 : _u.info, forceRefresh); });
-        this.getBalances = ({ forceRefresh } = { forceRefresh: false }) => __awaiter(this, void 0, void 0, function* () { var _v; return __classPrivateFieldGet(this, _WebSDK_getData, "f").call(this, __classPrivateFieldGet(this, _WebSDK_fetchUserBalances, "f"), (_v = this.user) === null || _v === void 0 ? void 0 : _v.balances, forceRefresh); });
-        this.getNfts = ({ forceRefresh } = { forceRefresh: false }) => __awaiter(this, void 0, void 0, function* () { var _w; return __classPrivateFieldGet(this, _WebSDK_getData, "f").call(this, __classPrivateFieldGet(this, _WebSDK_fetchUserNfts, "f"), (_w = this.user) === null || _w === void 0 ? void 0 : _w.nfts, forceRefresh); });
+        this.getWallets = ({ forceRefresh } = { forceRefresh: false }) => __awaiter(this, void 0, void 0, function* () { var _u; return __classPrivateFieldGet(this, _WebSDK_getData, "f").call(this, __classPrivateFieldGet(this, _WebSDK_fetchUserWallets, "f"), (_u = this.user) === null || _u === void 0 ? void 0 : _u.wallets, forceRefresh); });
+        this.getUserInfo = ({ forceRefresh } = { forceRefresh: false }) => __awaiter(this, void 0, void 0, function* () { var _v; return __classPrivateFieldGet(this, _WebSDK_getData, "f").call(this, __classPrivateFieldGet(this, _WebSDK_fetchUserInfo, "f"), (_v = this.user) === null || _v === void 0 ? void 0 : _v.info, forceRefresh); });
+        this.getBalances = ({ forceRefresh } = { forceRefresh: false }) => __awaiter(this, void 0, void 0, function* () { var _w; return __classPrivateFieldGet(this, _WebSDK_getData, "f").call(this, __classPrivateFieldGet(this, _WebSDK_fetchUserBalances, "f"), (_w = this.user) === null || _w === void 0 ? void 0 : _w.balances, forceRefresh); });
+        this.getNfts = ({ forceRefresh } = { forceRefresh: false }) => __awaiter(this, void 0, void 0, function* () { var _x; return __classPrivateFieldGet(this, _WebSDK_getData, "f").call(this, __classPrivateFieldGet(this, _WebSDK_fetchUserNfts, "f"), (_x = this.user) === null || _x === void 0 ? void 0 : _x.nfts, forceRefresh); });
         this.getTransactions = (props = {
             quantity: 0,
             getReceived: true,
             getSent: true,
             forceRefresh: false,
         }) => __awaiter(this, void 0, void 0, function* () {
-            var _x;
+            var _y;
             // Get all transactions encoded
             let { quantity, getReceived, getSent, forceRefresh } = props;
             if (quantity === undefined)
@@ -450,7 +450,7 @@ class WebSDK {
                 forceRefresh = false;
             if (!getSent && !getReceived)
                 throw new Error('getSent and getReceived cannot be both false');
-            const encoded = yield __classPrivateFieldGet(this, _WebSDK_getData, "f").call(this, __classPrivateFieldGet(this, _WebSDK_fetchTransactions, "f"), (_x = this.user) === null || _x === void 0 ? void 0 : _x.transactions, forceRefresh);
+            const encoded = yield __classPrivateFieldGet(this, _WebSDK_getData, "f").call(this, __classPrivateFieldGet(this, _WebSDK_fetchTransactions, "f"), (_y = this.user) === null || _y === void 0 ? void 0 : _y.transactions, forceRefresh);
             if (!encoded)
                 throw new Error("Couldn't get transactions");
             // Decode JWT payload to get raw transactions
@@ -484,32 +484,32 @@ class WebSDK {
             return txs;
         });
         this.isTokenExpired = () => __awaiter(this, void 0, void 0, function* () {
-            var _y, _z;
+            var _z, _0;
             if (!__classPrivateFieldGet(this, _WebSDK_credentials, "f")) {
-                const user = yield ((_y = __classPrivateFieldGet(this, _WebSDK_oauth2Client, "f")) === null || _y === void 0 ? void 0 : _y.getUser());
+                const user = yield ((_z = __classPrivateFieldGet(this, _WebSDK_oauth2Client, "f")) === null || _z === void 0 ? void 0 : _z.getUser());
                 if (user) {
                     return user.expires_at ? user.expires_at < Math.floor(Date.now() / 1000) : true;
                 }
                 else
                     return true;
             }
-            return ((_z = __classPrivateFieldGet(this, _WebSDK_credentials, "f")) === null || _z === void 0 ? void 0 : _z.expires_at)
+            return ((_0 = __classPrivateFieldGet(this, _WebSDK_credentials, "f")) === null || _0 === void 0 ? void 0 : _0.expires_at)
                 ? __classPrivateFieldGet(this, _WebSDK_credentials, "f").expires_at < Math.floor(Date.now() / 1000)
                 : true;
         });
         _WebSDK_refreshToken.set(this, () => __awaiter(this, void 0, void 0, function* () {
-            var _0, _1, _2, _3, _4, _5;
+            var _1, _2, _3, _4, _5, _6;
             try {
-                const user = yield ((_0 = __classPrivateFieldGet(this, _WebSDK_oauth2Client, "f")) === null || _0 === void 0 ? void 0 : _0.getUser());
-                if (((_1 = __classPrivateFieldGet(this, _WebSDK_credentials, "f")) === null || _1 === void 0 ? void 0 : _1.expires_at) &&
-                    ((_2 = __classPrivateFieldGet(this, _WebSDK_credentials, "f")) === null || _2 === void 0 ? void 0 : _2.expires_at) > Math.floor(Date.now() / 1000)) {
+                const user = yield ((_1 = __classPrivateFieldGet(this, _WebSDK_oauth2Client, "f")) === null || _1 === void 0 ? void 0 : _1.getUser());
+                if (((_2 = __classPrivateFieldGet(this, _WebSDK_credentials, "f")) === null || _2 === void 0 ? void 0 : _2.expires_at) &&
+                    ((_3 = __classPrivateFieldGet(this, _WebSDK_credentials, "f")) === null || _3 === void 0 ? void 0 : _3.expires_at) > Math.floor(Date.now() / 1000)) {
                     return user;
                 }
-                if (!((_3 = __classPrivateFieldGet(this, _WebSDK_credentials, "f")) === null || _3 === void 0 ? void 0 : _3.refreshToken) && user) {
+                if (!((_4 = __classPrivateFieldGet(this, _WebSDK_credentials, "f")) === null || _4 === void 0 ? void 0 : _4.refreshToken) && user) {
                     __classPrivateFieldGet(this, _WebSDK_instances, "m", _WebSDK_loadCredentials).call(this, user);
                 }
-                if ((_4 = __classPrivateFieldGet(this, _WebSDK_credentials, "f")) === null || _4 === void 0 ? void 0 : _4.refreshToken) {
-                    const userRefreshed = yield ((_5 = __classPrivateFieldGet(this, _WebSDK_oauth2Client, "f")) === null || _5 === void 0 ? void 0 : _5.signinSilent());
+                if ((_5 = __classPrivateFieldGet(this, _WebSDK_credentials, "f")) === null || _5 === void 0 ? void 0 : _5.refreshToken) {
+                    const userRefreshed = yield ((_6 = __classPrivateFieldGet(this, _WebSDK_oauth2Client, "f")) === null || _6 === void 0 ? void 0 : _6.signinSilent());
                     if (userRefreshed) {
                         __classPrivateFieldGet(this, _WebSDK_instances, "m", _WebSDK_loadCredentials).call(this, userRefreshed);
                         return userRefreshed;

--- a/dist/src/types.d.ts
+++ b/dist/src/types.d.ts
@@ -364,6 +364,13 @@ export interface PayResponseOnRampLink {
     };
     data: OnRampResponse;
 }
+export interface SDKPayResponseOnRampLink {
+    data: {
+        onrampLink: string;
+        status: TxStatus.PENDING;
+    };
+    error: 'insufficient balances';
+}
 export interface PayResponseRouteCreated {
     error: null;
     data: RouteResponse;

--- a/dist/src/types.d.ts
+++ b/dist/src/types.d.ts
@@ -350,16 +350,42 @@ export interface RouteResponse {
     status: TxStatus;
     route: Route;
 }
-export type PayResponse = {
-    error: 'insufficient balances';
+export interface PayErrorResponse {
+    error: string | {
+        code: string;
+        message: string;
+    };
+    data: null;
+}
+export interface PayResponseOnRampLink {
+    error: {
+        code: string;
+        message: string;
+    };
     data: OnRampResponse;
-} | {
+}
+export interface SDKPayResponseOnRampLink {
+    data: {
+        onrampLink: string;
+        status: TxStatus.PENDING;
+    };
+    error: 'insufficient balances';
+}
+export interface PayResponseRouteCreated {
     error: null;
     data: RouteResponse;
-} | {
-    error: string;
-    data: null;
-};
+}
+export interface PayResponse {
+    status: TxStatus;
+    route: Route;
+}
+export declare class PayError extends Error {
+    onrampLink?: string;
+    constructor({ message, onrampLink }: {
+        message: string;
+        onrampLink?: string;
+    });
+}
 export interface UserBalance {
     balances: WalletBalance[];
     total: string;

--- a/dist/src/types.d.ts
+++ b/dist/src/types.d.ts
@@ -364,13 +364,6 @@ export interface PayResponseOnRampLink {
     };
     data: OnRampResponse;
 }
-export interface SDKPayResponseOnRampLink {
-    data: {
-        onrampLink: string;
-        status: TxStatus.PENDING;
-    };
-    error: 'insufficient balances';
-}
 export interface PayResponseRouteCreated {
     error: null;
     data: RouteResponse;

--- a/dist/src/types.d.ts
+++ b/dist/src/types.d.ts
@@ -350,31 +350,16 @@ export interface RouteResponse {
     status: TxStatus;
     route: Route;
 }
-export interface PayErrorResponse {
-    error: string | {
-        code: string;
-        message: string;
-    };
-    data: null;
-}
-export interface PayResponseOnRampLink {
-    error: {
-        code: string;
-        message: string;
-    };
-    data: OnRampResponse;
-}
-export interface SDKPayResponseOnRampLink {
-    data: {
-        onrampLink: string;
-        status: TxStatus.PENDING;
-    };
+export type PayResponse = {
     error: 'insufficient balances';
-}
-export interface PayResponseRouteCreated {
+    data: OnRampResponse;
+} | {
     error: null;
     data: RouteResponse;
-}
+} | {
+    error: string;
+    data: null;
+};
 export interface UserBalance {
     balances: WalletBalance[];
     total: string;

--- a/dist/src/types.js
+++ b/dist/src/types.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.TransferType = exports.BridgeServices = exports.RouteActionType = exports.TxStatus = exports.Environments = exports.WalletTypes = exports.SupportedChains = exports.LoginBehavior = void 0;
+exports.PayError = exports.TransferType = exports.BridgeServices = exports.RouteActionType = exports.TxStatus = exports.Environments = exports.WalletTypes = exports.SupportedChains = exports.LoginBehavior = void 0;
 var LoginBehavior;
 (function (LoginBehavior) {
     LoginBehavior["REDIRECT"] = "REDIRECT";
@@ -62,3 +62,11 @@ var TransferType;
     TransferType["ERC20"] = "ERC20";
     TransferType["SPL"] = "SPL";
 })(TransferType || (exports.TransferType = TransferType = {}));
+class PayError extends Error {
+    constructor({ message, onrampLink }) {
+        super(message);
+        this.name = 'PayError';
+        this.onrampLink = onrampLink;
+    }
+}
+exports.PayError = PayError;

--- a/index.ts
+++ b/index.ts
@@ -443,7 +443,7 @@ class WebSDK {
         if (
           onRampResponse.error?.code === 'empty-balances' ||
           onRampResponse.error?.code === 'insufficient-balances' ||
-          onRampResponse.error?.message.includes('Not sufficient funds to bridge')
+          onRampResponse.error?.message?.includes('Not sufficient funds to bridge')
         ) {
           const onrampLink = onRampResponse.data?.onrampLink;
           throw new PayError({

--- a/index.ts
+++ b/index.ts
@@ -20,11 +20,11 @@ import {
   LoadCredentialsParams,
   ForceRefresh,
   SupportedChains,
-  TxStatus,
   PayResponse,
 } from './src/types';
 import { UserManager, WebStorageStateStore } from 'oidc-client-ts';
 import { decodeJWT } from './src/utils';
+import jwtDecode from 'jwt-decode';
 
 export { Environments as SphereEnvironment } from './src/types';
 export { SupportedChains } from './src/types';
@@ -443,7 +443,6 @@ class WebSDK {
           return { data: null, error: payResponse?.error?.message || payResponse?.error };
         }
       } else {
-        console.log('payResponse', payResponse);
         debugger;
         return payResponse;
       }
@@ -488,6 +487,8 @@ class WebSDK {
     if (getReceived === undefined) getReceived = true;
     if (getSent === undefined) getSent = true;
     if (forceRefresh === undefined) forceRefresh = false;
+
+    if (!getSent && !getReceived) throw new Error('getSent and getReceived cannot be both false');
 
     const encoded = await this.#getData(
       this.#fetchTransactions,

--- a/index.ts
+++ b/index.ts
@@ -359,13 +359,20 @@ class WebSDK {
     isTest?: boolean;
   }): Promise<ChargeUrlAndId> => {
     try {
-      const requestOptions = await this.#createRequest(
-        'POST',
-        { chargeData, isDirectTransfer, isTest },
-        { 'x-api-key': this.apiKey ?? '' }
-      );
+      // this endpoint doesn't need to have an a valid access token as header
+      const myHeaders = new Headers();
+      myHeaders.append('Content-Type', 'application/json');
+      myHeaders.append('x-api-key', this.apiKey);
+      const response = await fetch(`${this.#baseUrl}/createCharge`, {
+        headers: { ...myHeaders },
+        method: 'POST',
+        body: JSON.stringify({
+          chargeData,
+          isDirectTransfer,
+          isTest,
+        }),
+      });
 
-      const response = await fetch(`${this.#baseUrl}/createCharge`, requestOptions);
       const data = (await response.json()) as ChargeResponse;
       if (data.error) throw new Error(data.error);
       return data.data as ChargeUrlAndId;

--- a/src/types.ts
+++ b/src/types.ts
@@ -394,10 +394,6 @@ export interface PayResponseOnRampLink {
   error: { code: string; message: string };
   data: OnRampResponse;
 }
-export interface SDKPayResponseOnRampLink {
-  data: { onrampLink: string; status: TxStatus.PENDING };
-  error: 'insufficient balances';
-}
 export interface PayResponseRouteCreated {
   error: null;
   data: RouteResponse;

--- a/src/types.ts
+++ b/src/types.ts
@@ -396,6 +396,10 @@ export interface PayResponseOnRampLink {
   error: { code: string; message: string };
   data: OnRampResponse;
 }
+export interface SDKPayResponseOnRampLink {
+  data: { onrampLink: string; status: TxStatus.PENDING };
+  error: 'insufficient balances';
+}
 
 export interface PayResponseRouteCreated {
   error: null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -382,16 +382,40 @@ export interface OnRampResponse {
   status: TxStatus;
   onrampLink: string;
 }
-
 export interface RouteResponse {
   status: TxStatus;
   route: Route;
 }
+export interface PayErrorResponse {
+  error: string | { code: string; message: string };
+  data: null;
+}
+export interface PayResponseOnRampLink {
+  error: { code: string; message: string };
+  data: OnRampResponse;
+}
+export interface SDKPayResponseOnRampLink {
+  data: { onrampLink: string; status: TxStatus.PENDING };
+  error: 'insufficient balances';
+}
+export interface PayResponseRouteCreated {
+  error: null;
+  data: RouteResponse;
+}
+export interface PayResponse {
+  status: TxStatus;
+  route: Route;
+}
 
-export type PayResponse =
-  | { error: 'insufficient balances'; data: OnRampResponse }
-  | { error: null; data: RouteResponse }
-  | { error: string; data: null };
+export class PayError extends Error {
+  onrampLink?: string;
+
+  constructor({ message, onrampLink }: { message: string; onrampLink?: string }) {
+    super(message);
+    this.name = 'PayError';
+    this.onrampLink = onrampLink;
+  }
+}
 export interface UserBalance {
   balances: WalletBalance[];
   total: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -387,25 +387,11 @@ export interface RouteResponse {
   status: TxStatus;
   route: Route;
 }
-export interface PayErrorResponse {
-  error: string | { code: string; message: string };
-  data: null;
-}
 
-export interface PayResponseOnRampLink {
-  error: { code: string; message: string };
-  data: OnRampResponse;
-}
-export interface SDKPayResponseOnRampLink {
-  data: { onrampLink: string; status: TxStatus.PENDING };
-  error: 'insufficient balances';
-}
-
-export interface PayResponseRouteCreated {
-  error: null;
-  data: RouteResponse;
-}
-
+export type PayResponse =
+  | { error: 'insufficient balances'; data: OnRampResponse }
+  | { error: null; data: RouteResponse }
+  | { error: string; data: null };
 export interface UserBalance {
   balances: WalletBalance[];
   total: string;


### PR DESCRIPTION
### **PR Description**

[JIRA ticket](https://sphereone.atlassian.net/browse/ENG-1851)
[JIRA ticket](https://sphereone.atlassian.net/browse/ENG-1871)


This PR is to modify the way that we handle the error inside `pay/payCharge`, so the developer in the frontend doesn't have to do that strange logic to check if there is an error and onrampLink inside the .then() or the response.

Now he/she can do something like this
```
 sdk.payCharge(transactionId)
              .then((res) => {
                console.log("response in pay", res);
              })
              .catch((err) => {
                console.error("error in pay", err, err.message);
                if (err.onrampLink) {
                  console.log("this is the onrampLink", err.onrampLink);
                }
              });
```

Besides that I changed the logic inside `createCharge` to not require the access token (or a user logged in)

And finally fix a little bug inside `getTransactions`. In the case that you send as parameters `getSent` and `getReceived` both in false, it was causing the function to return just the transactions received when it shouldn't be possible to have both property in false.

### **Changelog**
- Refactor `pay/payCharge response `
- Allow `createCharge` to be called without a user logged in
- Fix a minor bug in `getTransactions`