### PR TITLE
Improve error handler in pay/payCharge

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -371,7 +371,9 @@ class WebSDK {
                     }
                     else {
                         const errorResponse = res;
-                        throw new Error(`Payment failed: ${errorResponse.error}`);
+                        throw new Error(`Payment failed: ${typeof errorResponse.error === 'string'
+                            ? errorResponse.error
+                            : errorResponse.error.message || errorResponse.error.code}`);
                     }
                 }
                 else {
@@ -410,7 +412,9 @@ class WebSDK {
                     }
                     else {
                         const errorResponse = res;
-                        throw new Error(`Payment failed: ${errorResponse.error}`);
+                        throw new Error(`Payment failed: ${typeof errorResponse.error === 'string'
+                            ? errorResponse.error
+                            : errorResponse.error.message || errorResponse.error.code}`);
                     }
                 }
                 else {

--- a/index.ts
+++ b/index.ts
@@ -417,7 +417,13 @@ class WebSDK {
           });
         } else {
           const errorResponse = res as PayErrorResponse;
-          throw new Error(`Payment failed: ${errorResponse.error}`);
+          throw new Error(
+            `Payment failed: ${
+              typeof errorResponse.error === 'string'
+                ? errorResponse.error
+                : errorResponse.error.message || errorResponse.error.code
+            }`
+          );
         }
       } else {
         const payResponse = (res as PayResponseRouteCreated).data;
@@ -452,7 +458,13 @@ class WebSDK {
           });
         } else {
           const errorResponse = res as PayErrorResponse;
-          throw new Error(`Payment failed: ${errorResponse.error}`);
+          throw new Error(
+            `Payment failed: ${
+              typeof errorResponse.error === 'string'
+                ? errorResponse.error
+                : errorResponse.error.message || errorResponse.error.code
+            }`
+          );
         }
       } else {
         const payResponse = (res as PayResponseRouteCreated).data;


### PR DESCRIPTION
### **PR Description**

We have some responses in the backend that has the schema `{data: null, error: string}` and others that have `{data: null, error: {code:string, message:string}`. 
With this change we can handle correctly both.

### **Changelog**
- Improve error handler in pay/payCharge