### PR TITLE
Added smart contract calls as per server and dashboard needs

### DIFF
--- a/dist/src/types.d.ts
+++ b/dist/src/types.d.ts
@@ -139,7 +139,13 @@ export type ChargeReqBody = {
     cancelUrl: string;
     amount?: number;
     toAddress?: string;
+    callSmartContractProps?: CallSmartContractProps;
 };
+export interface CallSmartContractProps {
+    alias: string;
+    nativeValue: string;
+    functionParams: string[];
+}
 export interface ChargeUrlAndId {
     paymentUrl: string;
     chargeId: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -154,7 +154,15 @@ export type ChargeReqBody = {
   cancelUrl: string;
   amount?: number;
   toAddress?: string;
+  // for calling on smart contract functions that are whitelisted in Merchant Dashboard
+  callSmartContractProps?: CallSmartContractProps;
 };
+
+export interface CallSmartContractProps {
+  alias: string;
+  nativeValue: string; // must be a string convertable to number
+  functionParams: string[];
+}
 
 export interface ChargeUrlAndId {
   paymentUrl: string;


### PR DESCRIPTION
### **PR Description**

Jira tickets:
- [ENG-2298](https://sphereone.atlassian.net/browse/ENG-2298)

This PR has changes to add `CallSmartContractProps` props to `ChargeReqBody`, so merchants can embed on their smart contract functions at the end of the payment flow. So, instead of transferring money to a merchant wallet, we trigger the smart contract function and send money to that smart contract instead.


[ENG-2298]: https://sphereone.atlassian.net/browse/ENG-2298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ